### PR TITLE
Add possibility to install via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,124 @@
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
 # widis-lstm-tools v0.1
+
 Various Tools for working with Long Short-Term Memory (LSTM) networks and sequences in [Pytorch](https://pytorch.org/),
 aimed at getting your LSTM networks under control and providing a flexible template for your LSTM-needs.
 
 LSTM paper (not earliest): https://www.mitpressjournals.org/doi/abs/10.1162/neco.1997.9.8.1735
 
 ## Quickstart
-Include the path to the `widis_lstm_tools` folder in you PYTHONPATH variable.
+
+You can directly install the package from GitHub using the command below:
+
+```bash
+pip install git+https://github.com/widmi/widis-lstm-tools
+```
 
 Run the simple example via
 
-```python3 widis_lstm_tools/examples/basic/main.py config.json```
+`python3 widis_lstm_tools/examples/basic/main.py config.json`
 
 Run the more advanced example via
 
-```python3 widis_lstm_tools/examples/model_selection/main.py config.json```
+`python3 widis_lstm_tools/examples/model_selection/main.py config.json`
 
 ## Includes
+
 - Flexible [LSTM implementation](widis_lstm_tools/nn.py#L69) including
   - Easy access to individual forward and recurrent LSTM connections and biases, with options to cut/modify individual connections to gates or cell input (see e.g. https://arxiv.org/abs/1503.04069 for some useful modifications)
   - Plotting function for LSTM internal states
@@ -31,12 +38,11 @@ Run the more advanced example via
 - Documented examples
   - [Basic LSTM example](widis_lstm_tools/examples/basic/main.py) with variable sequence lenghts
   - [Advanced LSTM example](widis_lstm_tools/examples/model_selection/main.py) with input encoding and model selection
- 
 
 ## Requirements
+
 - [Python3.6](https://www.python.org/) or higher
 - Python packages:
-   - [Pytorch](https://pytorch.org/) (tested with version 1.0.1)
-   - [numpy](https://www.numpy.org/) (tested with version 1.16.2)
-   - [matplotlib](https://matplotlib.org/) (tested with version 3.0.3)
-
+  - [Pytorch](https://pytorch.org/) (tested with version 1.0.1)
+  - [numpy](https://www.numpy.org/) (tested with version 1.16.2)
+  - [matplotlib](https://matplotlib.org/) (tested with version 3.0.3)

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     url="https://github.com/widmi/widis-lstm-tools",
     license="GPL-3.0",
     description=(
-        "Various tools for working with Long Short-Term Memory (LSTM)",
-        "networks and sequences in Pytorch",
+        "Various tools for working with Long Short-Term Memory (LSTM) "
+        "networks and sequences in Pytorch"
     ),
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages, setup
+
+readme = open("README.md").read()
+requirements = {"install": ["torch", "numpy", "matplotlib"]}
+install_requires = requirements["install"]
+
+setup(
+    # Metadata
+    name="widis-lstm-tools",
+    version="0.1",
+    author="Michael Widrich",
+    author_email="widrich@ml.jku.at",
+    url="https://github.com/widmi/widis-lstm-tools",
+    license="GPL-3.0",
+    description=(
+        "Various tools for working with Long Short-Term Memory (LSTM)",
+        "networks and sequences in Pytorch",
+    ),
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    # Package info
+    packages=find_packages(),
+    zip_safe=True,
+    install_requires=install_requires,
+)


### PR DESCRIPTION
This pull request enables installation via `pip`:
```bash
pip install git+https://github.com/widmi/widis-lstm-tools
```

Also adds a `.gitignore` file for Python files, as installing it locally for development via
```bash
pip install -e .
```
will create additional folders.
